### PR TITLE
feat(domain): refactor TimeUnit from milliseconds to abstract TU [TD_031]

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -205,7 +205,9 @@
       "Bash(./scripts/core/build.ps1 help)",
       "Bash(./scripts/core/build.ps1 test --filter \"*Infrastructure*Events*Integration*\")",
       "Bash(./scripts/core/build.ps1 test --filter \"Category=Integration\")",
-      "Bash(./scripts/core/build.ps1 test --filter \"Category=ThreadSafety\")"
+      "Bash(./scripts/core/build.ps1 test --filter \"Category=ThreadSafety\")",
+      "Bash(./scripts/core/build.ps1 test --filter \"*TimeUnit*\")",
+      "Bash(./scripts/core/build.ps1 test --filter \"Category=Domain&Feature=Combat\")"
     ],
     "deny": [],
     "ask": [],

--- a/Docs/01-Active/Backlog.md
+++ b/Docs/01-Active/Backlog.md
@@ -1,7 +1,7 @@
 # Darklands Development Backlog
 
 
-**Last Updated**: 2025-09-10 20:08 (VS_011 revised for modal combat, TD_031 created for TimeUnit fix)
+**Last Updated**: 2025-09-10 21:02 (TD_031 TimeUnit TU refactor completed and archived)
 
 **Last Aging Check**: 2025-08-29
 > 📚 See BACKLOG_AGING_PROTOCOL.md for 3-10 day aging rules
@@ -154,38 +154,7 @@
 ## 📈 Important (Do Next)
 *Core features for current milestone, technical debt affecting velocity*
 
-### TD_031: Refactor TimeUnit from Milliseconds to Abstract TU
-**Status**: Proposed  
-**Owner**: Tech Lead → Dev Engineer
-**Size**: S (2h)
-**Priority**: Critical (blocks VS_011)
-**Created**: 2025-09-10 20:05
-**Complexity**: 3/10
-
-**Problem**: TimeUnit currently represents milliseconds (real-time) instead of abstract Time Units (TU) as defined in Glossary.
-- Shows "1000ms" instead of "100 TU" in UI
-- Comments reference "milliseconds" throughout
-- Maximum is 10,000 (implying 10 seconds) instead of game-scale values
-
-**Impact**:
-- Confusing for players and developers
-- Inconsistent with Glossary and ADR-013
-- Wrong conceptual model (tied to real-time instead of game time)
-
-**Solution**:
-1. Change TimeUnit internal representation to TU (not milliseconds)
-2. Update ToString() to show "{Value} TU" not "{Value}ms"
-3. Update standard values: Move=100 TU, Attack=100 TU (not 1000ms)
-4. Fix all comments/documentation references
-5. Update tests to use TU scale
-
-**Technical Approach**:
-- Simple find/replace of "milliseconds" → "time units"
-- Change ToString() format
-- Scale all existing values by 0.1 (1000ms → 100 TU)
-- No logic changes, just unit representation
-
----
+<!-- TD_031 moved to permanent archive (2025-09-10 21:02) - TimeUnit TU refactor completed successfully -->
 
 ### VS_013: Basic Enemy AI
 **Status**: Proposed

--- a/Docs/01-Active/Backlog.md
+++ b/Docs/01-Active/Backlog.md
@@ -1,7 +1,7 @@
 # Darklands Development Backlog
 
 
-**Last Updated**: 2025-09-10 18:28 (TD_013 Extract Test Data from Production Presenters archived)
+**Last Updated**: 2025-09-10 20:08 (VS_011 revised for modal combat, TD_031 created for TimeUnit fix)
 
 **Last Aging Check**: 2025-08-29
 > 📚 See BACKLOG_AGING_PROTOCOL.md for 3-10 day aging rules
@@ -10,8 +10,8 @@
 **CRITICAL**: Before creating new items, check and update the appropriate counter.
 
 - **Next BR**: 002
-- **Next TD**: 031  
-- **Next VS**: 011 
+- **Next TD**: 032  
+- **Next VS**: 014 
 
 
 **Protocol**: Check your type's counter → Use that number → Increment the counter → Update timestamp
@@ -78,7 +78,74 @@
 ## 🔥 Critical (Do First)
 *Blockers preventing other work, production bugs, dependencies for other features*
 
+### VS_011: Modal Combat Movement System (Stoneshard-style)
+**Status**: Approved  
+**Owner**: Dev Engineer
+**Size**: M (6h total - simpler than original)
+**Priority**: Critical
+**Created**: 2025-09-10 19:03
+**Updated**: 2025-09-10 20:08
+**Tech Breakdown**: Revised for modal combat
 
+**What**: Two-mode movement system - adjacent-only in combat, pathfinding in exploration
+**Why**: Creates tactical depth where movement vs action is a meaningful choice
+
+**Design Decision**: Modal combat like Stoneshard
+- **Combat Mode**: Move to adjacent tile OR use skill (costs full turn)
+- **Exploration Mode**: Click anywhere for A* pathfinding
+- **Kiting Enabled**: Intentional design - trade damage for positioning
+
+**Implementation Plan**:
+- **Phase 1**: Domain model (1h)
+  - GameMode enum (Combat/Exploration)
+  - Fixed action costs (Move=100 TU, Attack=100 TU, Wait=100 TU)
+  - Adjacent position validation only
+  
+- **Phase 2**: Application handlers (1.5h)
+  - CombatMoveCommand (adjacent only, full turn cost)
+  - ExploreMoveCommand (pathfinding, no combat)
+  - Mode switching logic
+  
+- **Phase 3**: Infrastructure (1.5h)
+  - Simple adjacent checker for combat
+  - A* pathfinding for exploration only
+  - State management for mode transitions
+  
+- **Phase 4**: UI differentiation (2h)
+  - Combat Mode: Highlight 8 adjacent tiles only
+  - Exploration Mode: Full pathfinding preview
+  - Clear mode indicator in UI
+  - Action feedback: "Move: 100 TU" (not distance-based)
+
+**Key Simplifications**:
+- NO complex movement cost calculations
+- NO movement range based on stats
+- Every combat action = 100 TU base (modified by speed)
+- Adjacent movement only in combat (8 tiles max)
+
+**Tactical Implications**:
+- Kiting costs 50% damage output (move turns vs attack turns)
+- Positioning matters more (can't reposition freely)
+- Terrain becomes critical (dead ends are dangerous)
+- Speed affects turn frequency, not movement range
+
+**Done When**:
+- [Combat Mode] Click adjacent tile → move there (100 TU cost)
+- [Combat Mode] Can't click non-adjacent tiles
+- [Exploration Mode] Click anywhere → pathfind there
+- Mode indicator clearly shows current mode
+- Combat auto-triggers when enemies nearby
+- Message log: "Player moved north (100 TU)"
+
+**Architectural Constraints** (MANDATORY):
+☑ Deterministic: Fixed 100 TU cost for all combat moves
+☑ Save-Ready: Position stored as grid coordinates (x,y)
+☑ Time-Independent: Turn-based, not real-time
+☑ Integer Math: No float calculations needed
+☑ Testable: Modal logic easy to unit test
+
+**Depends On**: TD_031 (TimeUnit fix to use TU not milliseconds)
+**Next Step**: Fix TimeUnit first, then implement Phase 1
 
 ---
 
@@ -86,6 +153,67 @@
 
 ## 📈 Important (Do Next)
 *Core features for current milestone, technical debt affecting velocity*
+
+### TD_031: Refactor TimeUnit from Milliseconds to Abstract TU
+**Status**: Proposed  
+**Owner**: Tech Lead → Dev Engineer
+**Size**: S (2h)
+**Priority**: Critical (blocks VS_011)
+**Created**: 2025-09-10 20:05
+**Complexity**: 3/10
+
+**Problem**: TimeUnit currently represents milliseconds (real-time) instead of abstract Time Units (TU) as defined in Glossary.
+- Shows "1000ms" instead of "100 TU" in UI
+- Comments reference "milliseconds" throughout
+- Maximum is 10,000 (implying 10 seconds) instead of game-scale values
+
+**Impact**:
+- Confusing for players and developers
+- Inconsistent with Glossary and ADR-013
+- Wrong conceptual model (tied to real-time instead of game time)
+
+**Solution**:
+1. Change TimeUnit internal representation to TU (not milliseconds)
+2. Update ToString() to show "{Value} TU" not "{Value}ms"
+3. Update standard values: Move=100 TU, Attack=100 TU (not 1000ms)
+4. Fix all comments/documentation references
+5. Update tests to use TU scale
+
+**Technical Approach**:
+- Simple find/replace of "milliseconds" → "time units"
+- Change ToString() format
+- Scale all existing values by 0.1 (1000ms → 100 TU)
+- No logic changes, just unit representation
+
+---
+
+### VS_013: Basic Enemy AI
+**Status**: Proposed
+**Owner**: Product Owner → Tech Lead
+**Size**: M (4-8h)  
+**Priority**: Important
+**Created**: 2025-09-10 19:03
+
+**What**: Simple but effective enemy AI for combat testing
+**Why**: Need opponents to validate combat system and create gameplay loop
+**How**:
+- Decision tree for action selection (move/attack/wait)
+- Target prioritization (closest/weakest/most dangerous)
+- Basic pathfinding to reach targets
+- Flee behavior when low health
+**Done When**:
+- Enemies move towards player intelligently
+- Enemies attack when in range
+- AI makes decisions based on game state
+- Different enemy types show different behaviors
+- AI actions integrate with scheduler
+
+**Architectural Constraints** (MANDATORY):
+☑ Deterministic: AI decisions based on seeded random
+☑ Save-Ready: AI state fully serializable
+☑ Time-Independent: Decisions based on game state not time
+☑ Integer Math: All AI calculations use integers
+☑ Testable: AI logic can be unit tested
 
 ---
 

--- a/src/Application/Combat/Commands/ExecuteAttackCommandHandler.cs
+++ b/src/Application/Combat/Commands/ExecuteAttackCommandHandler.cs
@@ -152,7 +152,7 @@ public class ExecuteAttackCommandHandler : IRequestHandler<ExecuteAttackCommand,
         }
 
         // Log attack timing information
-        _logger?.Information("Attack completed: {AttackerId} next turn in +{ActionCost}ms",
+        _logger?.Information("Attack completed: {AttackerId} next turn in +{ActionCost} TU",
             request.AttackerId, request.CombatAction.BaseCost.Value);
 
         // Step 7: Cleanup dead actor

--- a/src/Domain/Combat/CombatAction.cs
+++ b/src/Domain/Combat/CombatAction.cs
@@ -107,35 +107,35 @@ public readonly record struct CombatAction
     {
         public static readonly CombatAction DaggerStab = CreateUnsafe(
             "Dagger Stab",
-            TimeUnit.CreateUnsafe(500),
+            TimeUnit.CreateUnsafe(50),
             8,
             CombatActionType.Attack,
             10);
 
         public static readonly CombatAction SwordSlash = CreateUnsafe(
             "Sword Slash",
-            TimeUnit.CreateUnsafe(800),
+            TimeUnit.CreateUnsafe(80),
             15,
             CombatActionType.Attack,
             0);
 
         public static readonly CombatAction AxeChop = CreateUnsafe(
             "Axe Chop",
-            TimeUnit.CreateUnsafe(1200),
+            TimeUnit.CreateUnsafe(120),
             22,
             CombatActionType.Attack,
             -5);
 
         public static readonly CombatAction Block = CreateUnsafe(
             "Block",
-            TimeUnit.CreateUnsafe(300),
+            TimeUnit.CreateUnsafe(30),
             0,
             CombatActionType.Defensive,
             0);
 
         public static readonly CombatAction Dodge = CreateUnsafe(
             "Dodge",
-            TimeUnit.CreateUnsafe(200),
+            TimeUnit.CreateUnsafe(20),
             0,
             CombatActionType.Defensive,
             0);

--- a/src/Domain/Combat/TimeUnitCalculator.cs
+++ b/src/Domain/Combat/TimeUnitCalculator.cs
@@ -70,7 +70,7 @@ public static class TimeUnitCalculator
             var finalTime = (numerator + denominator / 2) / denominator;
 
             // Ensure result is within valid bounds
-            return TimeUnit.FromMilliseconds(finalTime);
+            return TimeUnit.FromTU(finalTime);
         }
         catch (Exception ex)
         {

--- a/tests/Application/Combat/Coordination/GameLoopCoordinatorTests.cs
+++ b/tests/Application/Combat/Coordination/GameLoopCoordinatorTests.cs
@@ -150,8 +150,8 @@ namespace Darklands.Core.Tests.Application.Combat.Coordination
             // Arrange
             var actors = new[]
             {
-                CreateMockSchedulable(ActorId.NewId(TestIdGenerator.Instance), TimeUnit.FromMilliseconds(1000).IfFail(TimeUnit.Zero)),
-                CreateMockSchedulable(ActorId.NewId(TestIdGenerator.Instance), TimeUnit.FromMilliseconds(2000).IfFail(TimeUnit.Zero))
+                CreateMockSchedulable(ActorId.NewId(TestIdGenerator.Instance), TimeUnit.FromTU(100).IfFail(TimeUnit.Zero)),
+                CreateMockSchedulable(ActorId.NewId(TestIdGenerator.Instance), TimeUnit.FromTU(200).IfFail(TimeUnit.Zero))
             };
 
             _mockMediator.Setup(m => m.Send(It.IsAny<ScheduleActorCommand>(), default))
@@ -177,8 +177,8 @@ namespace Darklands.Core.Tests.Application.Combat.Coordination
             // Arrange
             var actors = new[]
             {
-                CreateMockSchedulable(ActorId.NewId(TestIdGenerator.Instance), TimeUnit.FromMilliseconds(1000).IfFail(TimeUnit.Zero)),
-                CreateMockSchedulable(ActorId.NewId(TestIdGenerator.Instance), TimeUnit.FromMilliseconds(2000).IfFail(TimeUnit.Zero))
+                CreateMockSchedulable(ActorId.NewId(TestIdGenerator.Instance), TimeUnit.FromTU(100).IfFail(TimeUnit.Zero)),
+                CreateMockSchedulable(ActorId.NewId(TestIdGenerator.Instance), TimeUnit.FromTU(200).IfFail(TimeUnit.Zero))
             };
 
             _mockMediator.SetupSequence(m => m.Send(It.IsAny<ScheduleActorCommand>(), default))
@@ -203,8 +203,8 @@ namespace Darklands.Core.Tests.Application.Combat.Coordination
             // Arrange
             var expectedActors = new List<ISchedulable>
             {
-                CreateMockSchedulable(ActorId.NewId(TestIdGenerator.Instance), TimeUnit.FromMilliseconds(1000).IfFail(TimeUnit.Zero)),
-                CreateMockSchedulable(ActorId.NewId(TestIdGenerator.Instance), TimeUnit.FromMilliseconds(2000).IfFail(TimeUnit.Zero))
+                CreateMockSchedulable(ActorId.NewId(TestIdGenerator.Instance), TimeUnit.FromTU(100).IfFail(TimeUnit.Zero)),
+                CreateMockSchedulable(ActorId.NewId(TestIdGenerator.Instance), TimeUnit.FromTU(200).IfFail(TimeUnit.Zero))
             };
 
             _mockMediator.Setup(m => m.Send(It.IsAny<GetSchedulerQuery>(), default))
@@ -228,7 +228,7 @@ namespace Darklands.Core.Tests.Application.Combat.Coordination
             // Arrange
             var actors = new List<ISchedulable>
             {
-                CreateMockSchedulable(ActorId.NewId(TestIdGenerator.Instance), TimeUnit.FromMilliseconds(1000).IfFail(TimeUnit.Zero))
+                CreateMockSchedulable(ActorId.NewId(TestIdGenerator.Instance), TimeUnit.FromTU(100).IfFail(TimeUnit.Zero))
             };
 
             _mockMediator.Setup(m => m.Send(It.IsAny<GetSchedulerQuery>(), default))

--- a/tests/Domain/Combat/CombatActionTests.cs
+++ b/tests/Domain/Combat/CombatActionTests.cs
@@ -189,7 +189,7 @@ public class CombatActionTests
 
         // Assert
         dagger.Name.Should().Be("Dagger Stab");
-        dagger.BaseCost.Value.Should().Be(500);
+        dagger.BaseCost.Value.Should().Be(50);
         dagger.BaseDamage.Should().Be(8);
         dagger.Type.Should().Be(CombatActionType.Attack);
         dagger.AccuracyBonus.Should().Be(10);
@@ -204,7 +204,7 @@ public class CombatActionTests
 
         // Assert
         sword.Name.Should().Be("Sword Slash");
-        sword.BaseCost.Value.Should().Be(800);
+        sword.BaseCost.Value.Should().Be(80);
         sword.BaseDamage.Should().Be(15);
         sword.Type.Should().Be(CombatActionType.Attack);
         sword.AccuracyBonus.Should().Be(0);
@@ -219,7 +219,7 @@ public class CombatActionTests
 
         // Assert
         axe.Name.Should().Be("Axe Chop");
-        axe.BaseCost.Value.Should().Be(1200);
+        axe.BaseCost.Value.Should().Be(120);
         axe.BaseDamage.Should().Be(22);
         axe.Type.Should().Be(CombatActionType.Attack);
         axe.AccuracyBonus.Should().Be(-5);
@@ -234,7 +234,7 @@ public class CombatActionTests
 
         // Assert
         block.Name.Should().Be("Block");
-        block.BaseCost.Value.Should().Be(300);
+        block.BaseCost.Value.Should().Be(30);
         block.BaseDamage.Should().Be(0);
         block.Type.Should().Be(CombatActionType.Defensive);
         block.AccuracyBonus.Should().Be(0);
@@ -249,7 +249,7 @@ public class CombatActionTests
 
         // Assert
         dodge.Name.Should().Be("Dodge");
-        dodge.BaseCost.Value.Should().Be(200);
+        dodge.BaseCost.Value.Should().Be(20);
         dodge.BaseDamage.Should().Be(0);
         dodge.Type.Should().Be(CombatActionType.Defensive);
         dodge.AccuracyBonus.Should().Be(0);

--- a/tests/Domain/Combat/TimeUnitCalculatorDeterminismTests.cs
+++ b/tests/Domain/Combat/TimeUnitCalculatorDeterminismTests.cs
@@ -23,11 +23,11 @@ public class TimeUnitCalculatorDeterminismTests
     public bool CalculateActionTime_IdenticalInputs_ProduceIdenticalResults(ushort baseTimeSeed, byte agilitySeed, byte encumbranceSeed)
     {
         // Arrange: Generate valid inputs from seeds
-        var baseTime = baseTimeSeed % 5000 + 100; // 100-5099ms range
+        var baseTime = (baseTimeSeed % 500 + 10); // 10-509 TU range (direct TU values)
         var agility = agilitySeed % TimeUnitCalculator.MaximumAgility + TimeUnitCalculator.MinimumAgility;
         var encumbrance = encumbranceSeed % (TimeUnitCalculator.MaximumEncumbrance + 1);
 
-        var action = CombatAction.CreateUnsafe("TestAction", TimeUnit.FromMilliseconds(baseTime).Match(t => t, _ => TimeUnit.Zero), 10);
+        var action = CombatAction.CreateUnsafe("TestAction", TimeUnit.FromTU(baseTime).Match(t => t, _ => TimeUnit.Zero), 10);
 
         // Act: Calculate the same result multiple times
         var results = new List<int>();
@@ -47,7 +47,7 @@ public class TimeUnitCalculatorDeterminismTests
     public void CalculateActionTime_RepeatedCalls_ProducesIdenticalResults()
     {
         // Arrange: Use the exact problematic values from original BR_001 report
-        var action = CombatAction.Common.SwordSlash; // 800ms base
+        var action = CombatAction.Common.SwordSlash; // 80 TU base
         var agility = 33; // Creates 100/33 division (was problematic in floating-point)
         var encumbrance = 7; // Creates 1 + 7*0.1 = 1.7 multiplier
 
@@ -65,10 +65,10 @@ public class TimeUnitCalculatorDeterminismTests
         uniqueResults.Count.Should().Be(1, "All calculations must return identical results");
 
         // Verify the specific expected result using integer arithmetic
-        // Original formula: 800 * (100/33) * (1 + 7*0.1)
-        // Integer formula: (800 * 100 * (10 + 7)) / (33 * 10)
-        // = (800 * 100 * 17) / 330 = 1,360,000 / 330 = 4121.212... → 4121 (with proper rounding)
-        var expectedResult = (800 * 100 * (10 + 7) + 33 * 10 / 2) / (33 * 10);
+        // Original formula: 80 * (100/33) * (1 + 7*0.1) (80 TU instead of 800ms)
+        // Integer formula: (80 * 100 * (10 + 7)) / (33 * 10)
+        // = (80 * 100 * 17) / 330 = 136,000 / 330 = 412.121... → 412 (with proper rounding)
+        var expectedResult = (80 * 100 * (10 + 7) + 33 * 10 / 2) / (33 * 10);
         results.First().Should().Be(expectedResult, "Result should match integer arithmetic calculation");
     }
 
@@ -78,7 +78,7 @@ public class TimeUnitCalculatorDeterminismTests
         // Test that the order of operations doesn't affect results
         var agility = agilitySeed % 100 + 1; // 1-100
         var encumbrance = encumbranceSeed % 51; // 0-50
-        var baseTime = 1000;
+        var baseTime = 100; // 100 TU instead of 1000ms
 
         // Calculate using the implemented formula: (baseTime * 100 * (10 + encumbrance)) / (agility * 10)
         var numerator = baseTime * 100 * (10 + encumbrance);
@@ -144,8 +144,8 @@ public class TimeUnitCalculatorDeterminismTests
         result.IsSucc.Should().BeTrue();
 
         // The result should be calculable using ONLY integer arithmetic
-        // Formula: (500 * 100 * (10 + 13) + 210) / 420 = (500 * 100 * 23 + 210) / 420
-        var expected = (500 * 100 * 23 + 420 / 2) / 420;
+        // Formula: (50 * 100 * (10 + 13) + 210) / 420 = (50 * 100 * 23 + 210) / 420 (50 TU instead of 500ms)
+        var expected = (50 * 100 * 23 + 420 / 2) / 420;
 
         result.IfSucc(time => time.Value.Should().Be(expected));
 

--- a/tests/Domain/Combat/TimeUnitCalculatorTests.cs
+++ b/tests/Domain/Combat/TimeUnitCalculatorTests.cs
@@ -21,7 +21,7 @@ public class TimeUnitCalculatorTests
     public void CalculateActionTime_ValidInputs_ReturnsExpectedTime()
     {
         // Arrange
-        var daggerStab = CombatAction.Common.DaggerStab; // 500ms base
+        var daggerStab = CombatAction.Common.DaggerStab; // 50 TU base
         var agility = 20; // 100/20 = 5.0 modifier
         var encumbrance = 0; // 1.0 + (0 * 0.1) = 1.0 modifier
 
@@ -32,8 +32,8 @@ public class TimeUnitCalculatorTests
         result.IsSucc.Should().BeTrue();
         result.IfSucc(time =>
         {
-            // Expected: 500 * (100/20) * (1 + 0*0.1) = 500 * 5 * 1 = 2500
-            time.Value.Should().Be(2500);
+            // Expected: 50 * (100/20) * (1 + 0*0.1) = 50 * 5 * 1 = 250
+            time.Value.Should().Be(250);
         });
     }
 

--- a/tests/Domain/Combat/TimeUnitTests.cs
+++ b/tests/Domain/Combat/TimeUnitTests.cs
@@ -37,7 +37,7 @@ public class TimeUnitTests
     }
 
     [Fact]
-    public void Minimum_ReturnsOneMillisecond()
+    public void Minimum_ReturnsOneTU()
     {
         // Act & Assert
         TimeUnit.Minimum.Value.Should().Be(1);
@@ -45,7 +45,7 @@ public class TimeUnitTests
     }
 
     [Fact]
-    public void Maximum_ReturnsTenSeconds()
+    public void Maximum_ReturnsTenThousandTU()
     {
         // Act & Assert
         TimeUnit.Maximum.Value.Should().Be(10_000);
@@ -82,14 +82,14 @@ public class TimeUnitTests
     [InlineData(1)]
     [InlineData(1000)]
     [InlineData(10_000)]
-    public void FromMilliseconds_ValidValues_ReturnsSuccess(int milliseconds)
+    public void FromTU_ValidValues_ReturnsSuccess(int timeUnits)
     {
         // Act
-        var result = TimeUnit.FromMilliseconds(milliseconds);
+        var result = TimeUnit.FromTU(timeUnits);
 
         // Assert
         result.IsSucc.Should().BeTrue();
-        result.IfSucc(timeUnit => timeUnit.Value.Should().Be(milliseconds));
+        result.IfSucc(timeUnit => timeUnit.Value.Should().Be(timeUnits));
     }
 
     [Theory]
@@ -97,10 +97,10 @@ public class TimeUnitTests
     [InlineData(-1000)]
     [InlineData(10_001)]
     [InlineData(100_000)]
-    public void FromMilliseconds_InvalidValues_ReturnsFailure(int milliseconds)
+    public void FromTU_InvalidValues_ReturnsFailure(int timeUnits)
     {
         // Act
-        var result = TimeUnit.FromMilliseconds(milliseconds);
+        var result = TimeUnit.FromTU(timeUnits);
 
         // Assert
         result.IsFail.Should().BeTrue();
@@ -221,11 +221,11 @@ public class TimeUnitTests
     }
 
     [Theory]
-    [InlineData(500, "500ms")]
-    [InlineData(1000, "1.0s")]
-    [InlineData(1500, "1.5s")]
-    [InlineData(5000, "5.0s")]
-    [InlineData(10000, "10.0s")]
+    [InlineData(50, "50 TU")]
+    [InlineData(100, "100 TU")]
+    [InlineData(150, "150 TU")]
+    [InlineData(500, "500 TU")]
+    [InlineData(1000, "1000 TU")]
     public void ToString_VariousValues_ReturnsFormattedString(int value, string expected)
     {
         // Arrange


### PR DESCRIPTION
- **feat(domain): refactor TimeUnit from milliseconds to abstract TU [TD_031]**
  Changes:
  - TimeUnit now represents abstract Time Units (TU) instead of milliseconds
  - Updated ToString() to show "{Value} TU" format instead of milliseconds/seconds
  - Scaled CombatAction values: DaggerStab=50 TU (was 500ms), SwordSlash=80 TU (was 800ms)
  - Renamed FromMilliseconds() to FromTU() for clarity
  - Fixed all test expectations to use new TU values
  - Updated comments and documentation to reference TU instead of milliseconds
  - Maintained all existing functionality while fixing conceptual model
  
  Impact:
  - Consistent with Glossary definition of Time Units as abstract game time
  - UI will now show "50 TU" instead of confusing "500ms" for action costs
  - No behavioral changes - all tests pass (632/632)
  - Blocks VS_011 Modal Combat Movement System resolved
  
  🤖 Generated with [Claude Code](https://claude.ai/code)
  
  Co-Authored-By: Claude <noreply@anthropic.com>
  

- **docs(backlog): archive completed TD_031 TimeUnit TU refactor**
  - Moved TD_031 to permanent archive with completion timestamp
  - Updated backlog last updated timestamp
  - All TimeUnit refactoring work successfully completed
  
  🤖 Generated with [Claude Code](https://claude.ai/code)
  
  Co-Authored-By: Claude <noreply@anthropic.com>
  