### PR TITLE
feat(inventory): Slot-Based Inventory System (VS_008)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -205,7 +205,9 @@
       "Bash(./scripts/core/build.ps1 test --filter \"Category=Architecture\")",
       "Bash(./scripts/core/build.ps1 test --filter \"Category=Phase3\")",
       "Bash(identify:*)",
-      "Bash(timeout:*)"
+      "Bash(timeout:*)",
+      "Bash(test:*)",
+      "Bash(./scripts/core/build.ps1 test --filter \"Category=Phase1&FullyQualifiedName~Inventory\")"
     ],
     "deny": [],
     "ask": [],

--- a/Components/InventoryPanelNode.cs
+++ b/Components/InventoryPanelNode.cs
@@ -1,0 +1,239 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Godot;
+using Darklands.Core.Domain.Common;
+using Darklands.Core.Features.Inventory.Application.Commands;
+using Darklands.Core.Features.Inventory.Application.Queries;
+using Darklands.Core.Infrastructure.DependencyInjection;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Darklands.Components;
+
+/// <summary>
+/// Godot node that displays inventory UI with test buttons.
+/// Demonstrates slot-based inventory MVP for VS_008.
+///
+/// ARCHITECTURE (ADR-002):
+/// - Uses ServiceLocator.Get<T>() in _Ready() (Godot constraint)
+/// - No events in MVP: UI queries on-demand after commands
+/// - Commands: AddItemCommand, RemoveItemCommand
+/// - Query: GetInventoryQuery (returns DTO)
+/// </summary>
+public partial class InventoryPanelNode : VBoxContainer
+{
+    // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    // GODOT EDITOR PROPERTIES (will resolve in _Ready)
+    // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+    private Label? _capacityLabel;
+    private GridContainer? _slotsGrid;
+    private Button? _addItemButton;
+    private Button? _removeItemButton;
+
+    // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    // DEPENDENCIES (resolved via ServiceLocator in _Ready)
+    // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+    private IMediator? _mediator;
+    private ILogger<InventoryPanelNode>? _logger;
+
+    // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    // STATE
+    // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+    private ActorId _actorId;
+    private readonly List<ItemId> _addedItems = new();
+
+    // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    // GODOT LIFECYCLE
+    // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+    public override void _Ready()
+    {
+        base._Ready();
+
+        _logger?.LogInformation("InventoryPanelNode initializing...");
+
+        // GODOT 4 FIX: Must manually resolve nodes using GetNode()
+        _capacityLabel = GetNode<Label>("CapacityLabel");
+        _slotsGrid = GetNode<GridContainer>("SlotsGrid");
+        _addItemButton = GetNode<Button>("ButtonContainer/AddItemButton");
+        _removeItemButton = GetNode<Button>("ButtonContainer/RemoveItemButton");
+
+        // Resolve dependencies via ServiceLocator (Godot constraint)
+        var mediatorResult = ServiceLocator.GetService<IMediator>();
+        var loggerResult = ServiceLocator.GetService<ILogger<InventoryPanelNode>>();
+
+        if (mediatorResult.IsFailure || loggerResult.IsFailure)
+        {
+            GD.PrintErr("[InventoryPanelNode] Failed to resolve dependencies");
+            return;
+        }
+
+        _mediator = mediatorResult.Value;
+        _logger = loggerResult.Value;
+
+        // Create test actor (in real game, this would be the player's ActorId)
+        _actorId = ActorId.NewId();
+
+        _logger.LogInformation("InventoryPanelNode initialized for actor {ActorId}", _actorId);
+
+        // NOTE: Button signals connected in scene file (inventory_panel.tscn)
+        // Do NOT wire up here - causes double press!
+
+        // Initialize UI
+        _ = RefreshInventoryDisplay();
+    }
+
+    // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    // BUTTON HANDLERS (Send commands, then query for updated state)
+    // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+    private async void OnAddItemButtonPressed()
+    {
+        if (_mediator == null)
+        {
+            GD.PrintErr("[InventoryPanelNode] Cannot add item - mediator is null");
+            return;
+        }
+
+        var itemId = ItemId.NewId();
+        _logger?.LogDebug("Adding test item {ItemId}", itemId);
+
+        var command = new AddItemCommand(_actorId, itemId);
+        var result = await _mediator.Send(command);
+
+        if (result.IsFailure)
+        {
+            _logger?.LogWarning("Add item failed: {Error}", result.Error);
+            GD.PrintErr($"❌ Add failed: {result.Error}");
+        }
+        else
+        {
+            _addedItems.Add(itemId);
+            _logger?.LogInformation("Item {ItemId} added successfully", itemId);
+
+            // Refresh UI (no events in MVP, query on-demand)
+            await RefreshInventoryDisplay();
+        }
+    }
+
+    private async void OnRemoveItemButtonPressed()
+    {
+        if (_mediator == null)
+        {
+            GD.PrintErr("[InventoryPanelNode] Cannot remove item - mediator is null");
+            return;
+        }
+
+        // Remove last added item
+        if (_addedItems.Count == 0)
+        {
+            GD.Print("⚠️ No items to remove");
+            return;
+        }
+
+        var itemToRemove = _addedItems[^1];
+        _logger?.LogDebug("Removing item {ItemId}", itemToRemove);
+
+        var command = new RemoveItemCommand(_actorId, itemToRemove);
+        var result = await _mediator.Send(command);
+
+        if (result.IsFailure)
+        {
+            _logger?.LogWarning("Remove item failed: {Error}", result.Error);
+            GD.PrintErr($"❌ Remove failed: {result.Error}");
+        }
+        else
+        {
+            _addedItems.RemoveAt(_addedItems.Count - 1);
+            _logger?.LogInformation("Item {ItemId} removed successfully", itemToRemove);
+
+            // Refresh UI
+            await RefreshInventoryDisplay();
+        }
+    }
+
+    // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    // UI UPDATE (Query-based, no events)
+    // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+    private async Task RefreshInventoryDisplay()
+    {
+        if (_mediator == null || _capacityLabel == null || _slotsGrid == null || _addItemButton == null)
+            return;
+
+        // Query current inventory state
+        var query = new GetInventoryQuery(_actorId);
+        var result = await _mediator.Send(query);
+
+        if (result.IsFailure)
+        {
+            _logger?.LogError("Failed to query inventory: {Error}", result.Error);
+            return;
+        }
+
+        var inventory = result.Value;
+
+        // Update capacity label
+        _capacityLabel.Text = $"📦 Inventory: {inventory.Count}/{inventory.Capacity}";
+
+        // Update button states
+        _addItemButton.Disabled = inventory.IsFull;
+        _addItemButton.Text = inventory.IsFull ? "🚫 Inventory Full" : "➕ Add Test Item";
+
+        // Update slot visuals (simplified: just show count of filled slots)
+        // FUTURE: Show actual item sprites when Item definitions exist
+        _slotsGrid.GetChildren().Clear();
+
+        for (int i = 0; i < inventory.Capacity; i++)
+        {
+            var slot = new Panel();
+            slot.CustomMinimumSize = new Vector2(40, 40);
+
+            if (i < inventory.Count)
+            {
+                // Filled slot (show item ID last 4 chars)
+                var label = new Label
+                {
+                    Text = inventory.Items[i].ToString()[^4..],
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    VerticalAlignment = VerticalAlignment.Center
+                };
+                label.AddThemeColorOverride("font_color", Colors.White);
+                slot.AddChild(label);
+
+                // Style filled slot
+                var styleBox = new StyleBoxFlat
+                {
+                    BgColor = new Color(0.2f, 0.6f, 0.2f) // Green
+                };
+                styleBox.BorderWidthLeft = 2;
+                styleBox.BorderWidthRight = 2;
+                styleBox.BorderWidthTop = 2;
+                styleBox.BorderWidthBottom = 2;
+                styleBox.BorderColor = Colors.White;
+                slot.AddThemeStyleboxOverride("panel", styleBox);
+            }
+            else
+            {
+                // Empty slot
+                var styleBox = new StyleBoxFlat
+                {
+                    BgColor = new Color(0.2f, 0.2f, 0.2f) // Dark gray
+                };
+                styleBox.BorderWidthLeft = 1;
+                styleBox.BorderWidthRight = 1;
+                styleBox.BorderWidthTop = 1;
+                styleBox.BorderWidthBottom = 1;
+                styleBox.BorderColor = new Color(0.4f, 0.4f, 0.4f); // Gray border
+                slot.AddThemeStyleboxOverride("panel", styleBox);
+            }
+
+            _slotsGrid.AddChild(slot);
+        }
+
+        _logger?.LogDebug("Inventory display refreshed: {Count}/{Capacity}", inventory.Count, inventory.Capacity);
+    }
+}

--- a/Docs/01-Active/Backlog.md
+++ b/Docs/01-Active/Backlog.md
@@ -155,7 +155,12 @@
   - Tests: 10 test methods, 12 test executions, 100% pass rate (15ms)
   - Key insight: Namespace collision resolved using `InventoryEntity` alias (test namespace contains "Inventory" segment)
   - Architecture: Zero Godot dependencies, Result<T> for all operations, capacity enforcement (max 100 slots)
-  - **Next**: Phase 2 - Application layer (Commands, Queries, Handlers)
+- **✅ Phase 2 Complete** - Application layer implemented (2025-10-02 11:56)
+  - Implemented: AddItemCommand/RemoveItemCommand with handlers, GetInventoryQuery with DTO, IInventoryRepository interface
+  - Tests: 7 handler tests (3 add, 2 remove, 2 query), 100% pass rate (2ms)
+  - Key insight: Repository interface in Application (Dependency Inversion Principle), implementation in Infrastructure
+  - Railway-oriented: Handlers use `.Bind()`, `.Map()`, `.Tap()` for functional composition
+  - **Next**: Phase 3 - Infrastructure layer (DI registration) + Phase 4 - Presentation (UI)
 
 ---
 

--- a/Docs/01-Active/Backlog.md
+++ b/Docs/01-Active/Backlog.md
@@ -164,7 +164,11 @@
   - Implemented: DI registration in GameStrapper (AddSingleton pattern)
   - Tests: 4 repository tests (auto-creation, persistence, deletion), 100% pass rate (3ms)
   - Key insight: Repository is reference-type, so second GetByActorIdAsync returns same instance (no SaveAsync needed for in-memory)
-  - **Next**: Phase 4 - Presentation layer (Godot UI with test buttons)
+- **✅ Phase 4 Complete** - Presentation layer implemented (2025-10-02 12:10)
+  - Implemented: InventoryPanelNode.cs with ServiceLocator pattern, InventoryTestScene.tscn
+  - UI: GridContainer (10×2 = 20 slots), Add/Remove test buttons, dynamic slot visuals (green filled, gray empty)
+  - Key insight: No events in MVP - UI queries GetInventoryQuery after commands, ServiceLocator only in _Ready()
+  - **Manual Testing Required**: Open Godot → Run InventoryTestScene.tscn → Click Add Item 20 times → Verify button disables at 20/20
 
 ---
 

--- a/Docs/01-Active/Backlog.md
+++ b/Docs/01-Active/Backlog.md
@@ -149,6 +149,14 @@
 - **Loot drops**: Separate ground item system (future VS) - items at Position on map
 - **Explicit creation**: Must call `CreateInventoryCommand(actorId, capacity)` to give actor an inventory
 
+**Dev Engineer Progress**:
+- **✅ Phase 1 Complete** - Domain layer implemented (2025-10-02 11:53)
+  - Implemented: ItemId (Domain/Common), InventoryId, Inventory entity with business rules
+  - Tests: 10 test methods, 12 test executions, 100% pass rate (15ms)
+  - Key insight: Namespace collision resolved using `InventoryEntity` alias (test namespace contains "Inventory" segment)
+  - Architecture: Zero Godot dependencies, Result<T> for all operations, capacity enforcement (max 100 slots)
+  - **Next**: Phase 2 - Application layer (Commands, Queries, Handlers)
+
 ---
 
 ### VS_007: Smart Movement Interruption ⭐ **PLANNED**

--- a/Docs/01-Active/Backlog.md
+++ b/Docs/01-Active/Backlog.md
@@ -160,7 +160,11 @@
   - Tests: 7 handler tests (3 add, 2 remove, 2 query), 100% pass rate (2ms)
   - Key insight: Repository interface in Application (Dependency Inversion Principle), implementation in Infrastructure
   - Railway-oriented: Handlers use `.Bind()`, `.Map()`, `.Tap()` for functional composition
-  - **Next**: Phase 3 - Infrastructure layer (DI registration) + Phase 4 - Presentation (UI)
+- **✅ Phase 3 Complete** - Infrastructure layer implemented (2025-10-02 12:01)
+  - Implemented: DI registration in GameStrapper (AddSingleton pattern)
+  - Tests: 4 repository tests (auto-creation, persistence, deletion), 100% pass rate (3ms)
+  - Key insight: Repository is reference-type, so second GetByActorIdAsync returns same instance (no SaveAsync needed for in-memory)
+  - **Next**: Phase 4 - Presentation layer (Godot UI with test buttons)
 
 ---
 

--- a/godot_project/test_scenes/GridTestScene.tscn
+++ b/godot_project/test_scenes/GridTestScene.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=4 format=3 uid="uid://jn3k0ygbb4um"]
 
-[ext_resource type="Script" uid="uid://fxut2udfqbbd" path="res://godot_project/test_scenes/GridTestSceneController.cs" id="1_controller"]
+[ext_resource type="Script" uid="uid://ctf7y680lnus0" path="res://godot_project/test_scenes/GridTestSceneController.cs" id="1_controller"]
 [ext_resource type="TileSet" uid="uid://ctg8p3ufnuc2d" path="res://assets/grid_tileset.tres" id="2_kyx3r"]
 [ext_resource type="Texture2D" uid="uid://cpjo2p3va4g4k" path="res://assets/micro-roguelike/colored_tilemap.png" id="2_tilemap"]
 

--- a/godot_project/test_scenes/InventoryTestScene.tscn
+++ b/godot_project/test_scenes/InventoryTestScene.tscn
@@ -1,0 +1,84 @@
+[gd_scene load_steps=2 format=3 uid="uid://c4g4j5dgmbvoj"]
+
+[ext_resource type="Script" uid="uid://dqqw2lvwc8pj8" path="res://Components/InventoryPanelNode.cs" id="1_inventory"]
+
+[node name="InventoryTestScene" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="InventoryPanelNode" type="VBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -300.0
+offset_top = -250.0
+offset_right = 300.0
+offset_bottom = 250.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/separation = 15
+script = ExtResource("1_inventory")
+
+[node name="Title" type="Label" parent="InventoryPanelNode"]
+layout_mode = 2
+text = "🎒 Inventory System Test (VS_008 Phase 4)"
+horizontal_alignment = 1
+autowrap_mode = 3
+
+[node name="HSeparator" type="HSeparator" parent="InventoryPanelNode"]
+layout_mode = 2
+
+[node name="CapacityLabel" type="Label" parent="InventoryPanelNode"]
+layout_mode = 2
+text = "📦 Inventory: 0/20"
+horizontal_alignment = 1
+
+[node name="SlotsGrid" type="GridContainer" parent="InventoryPanelNode"]
+custom_minimum_size = Vector2(0, 250)
+layout_mode = 2
+size_flags_vertical = 3
+theme_override_constants/h_separation = 5
+theme_override_constants/v_separation = 5
+columns = 10
+
+[node name="HSeparator2" type="HSeparator" parent="InventoryPanelNode"]
+layout_mode = 2
+
+[node name="ButtonContainer" type="HBoxContainer" parent="InventoryPanelNode"]
+layout_mode = 2
+theme_override_constants/separation = 10
+
+[node name="AddItemButton" type="Button" parent="InventoryPanelNode/ButtonContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "➕ Add Test Item"
+
+[node name="RemoveItemButton" type="Button" parent="InventoryPanelNode/ButtonContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "➖ Remove Last Item"
+
+[node name="HSeparator3" type="HSeparator" parent="InventoryPanelNode"]
+layout_mode = 2
+
+[node name="Instructions" type="Label" parent="InventoryPanelNode"]
+layout_mode = 2
+text = "📋 Instructions:
+• Click 'Add Test Item' to add items to inventory
+• Inventory capacity: 20 slots (default)
+• Green slots = filled, gray slots = empty
+• Button disables when inventory full
+• Click 'Remove Last Item' to remove items
+• Validates: Command → Handler → Repository → Query → UI"
+horizontal_alignment = 1
+autowrap_mode = 3
+
+[connection signal="pressed" from="InventoryPanelNode/ButtonContainer/AddItemButton" to="InventoryPanelNode" method="OnAddItemButtonPressed"]
+[connection signal="pressed" from="InventoryPanelNode/ButtonContainer/RemoveItemButton" to="InventoryPanelNode" method="OnRemoveItemButtonPressed"]

--- a/src/Darklands.Core/Application/Infrastructure/GameStrapper.cs
+++ b/src/Darklands.Core/Application/Infrastructure/GameStrapper.cs
@@ -92,6 +92,10 @@ public static class GameStrapper
         // Movement System (VS_006 Phase 3+4) - Pathfinding service
         services.AddSingleton<Features.Movement.Application.Services.IPathfindingService,
             Features.Movement.Infrastructure.Services.AStarPathfindingService>();
+
+        // Inventory System (VS_008 Phase 3) - Repository
+        services.AddSingleton<Features.Inventory.Application.IInventoryRepository,
+            Features.Inventory.Infrastructure.InMemoryInventoryRepository>();
     }
 
     /// <summary>

--- a/src/Darklands.Core/Domain/Common/ItemId.cs
+++ b/src/Darklands.Core/Domain/Common/ItemId.cs
@@ -1,0 +1,33 @@
+namespace Darklands.Core.Domain.Common;
+
+/// <summary>
+/// Uniquely identifies an item in the game world.
+/// Value type with value semantics - two ItemIds with the same Guid are equal.
+/// </summary>
+/// <remarks>
+/// ItemId is a shared primitive used across multiple features:
+/// - Inventory (stores ItemId references)
+/// - Combat (tracks wielded weapon ItemId)
+/// - Loot (identifies dropped items)
+/// - Crafting (recipe inputs/outputs)
+/// </remarks>
+public readonly record struct ItemId(Guid Value)
+{
+    /// <summary>
+    /// Creates a new unique ItemId.
+    /// </summary>
+    public static ItemId NewId() => new(Guid.NewGuid());
+
+    /// <summary>
+    /// Creates an ItemId from a string representation.
+    /// </summary>
+    /// <param name="value">String representation of a Guid</param>
+    /// <returns>ItemId parsed from the string</returns>
+    /// <exception cref="FormatException">If the string is not a valid Guid format</exception>
+    public static ItemId From(string value) => new(Guid.Parse(value));
+
+    /// <summary>
+    /// Returns the string representation of this ItemId.
+    /// </summary>
+    public override string ToString() => Value.ToString();
+}

--- a/src/Darklands.Core/Features/Inventory/Application/Commands/AddItemCommand.cs
+++ b/src/Darklands.Core/Features/Inventory/Application/Commands/AddItemCommand.cs
@@ -1,0 +1,16 @@
+using CSharpFunctionalExtensions;
+using Darklands.Core.Domain.Common;
+using MediatR;
+
+namespace Darklands.Core.Features.Inventory.Application.Commands;
+
+/// <summary>
+/// Command to add an item to an actor's inventory.
+/// Pure DTO - no behavior, just data for the handler.
+/// </summary>
+/// <param name="ActorId">Actor whose inventory will receive the item</param>
+/// <param name="ItemId">Item to add</param>
+public sealed record AddItemCommand(
+    ActorId ActorId,
+    ItemId ItemId
+) : IRequest<Result>;

--- a/src/Darklands.Core/Features/Inventory/Application/Commands/RemoveItemCommand.cs
+++ b/src/Darklands.Core/Features/Inventory/Application/Commands/RemoveItemCommand.cs
@@ -1,0 +1,16 @@
+using CSharpFunctionalExtensions;
+using Darklands.Core.Domain.Common;
+using MediatR;
+
+namespace Darklands.Core.Features.Inventory.Application.Commands;
+
+/// <summary>
+/// Command to remove an item from an actor's inventory.
+/// Pure DTO - no behavior, just data for the handler.
+/// </summary>
+/// <param name="ActorId">Actor whose inventory will lose the item</param>
+/// <param name="ItemId">Item to remove</param>
+public sealed record RemoveItemCommand(
+    ActorId ActorId,
+    ItemId ItemId
+) : IRequest<Result>;

--- a/src/Darklands.Core/Features/Inventory/Application/IInventoryRepository.cs
+++ b/src/Darklands.Core/Features/Inventory/Application/IInventoryRepository.cs
@@ -1,0 +1,51 @@
+using CSharpFunctionalExtensions;
+using Darklands.Core.Domain.Common;
+using InventoryEntity = Darklands.Core.Features.Inventory.Domain.Inventory;
+using InventoryId = Darklands.Core.Features.Inventory.Domain.InventoryId;
+
+namespace Darklands.Core.Features.Inventory.Application;
+
+/// <summary>
+/// Repository contract for managing inventory persistence.
+/// Defined in Application layer (Dependency Inversion Principle).
+/// Implemented in Infrastructure layer.
+/// </summary>
+/// <remarks>
+/// ASYNC DESIGN: Methods are async even though in-memory implementation is synchronous.
+/// This future-proofs for SQLite/JSON persistence without changing consumers.
+///
+/// AUTO-CREATION: GetByActorIdAsync auto-creates inventory if it doesn't exist.
+/// This eliminates boilerplate for MVP (all player-controlled actors need inventories).
+/// </remarks>
+public interface IInventoryRepository
+{
+    /// <summary>
+    /// Retrieves an actor's inventory. Auto-creates if doesn't exist.
+    /// </summary>
+    /// <param name="actorId">Actor whose inventory to retrieve</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Result containing Inventory or error message</returns>
+    Task<Result<InventoryEntity>> GetByActorIdAsync(
+        ActorId actorId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Persists inventory changes.
+    /// </summary>
+    /// <param name="inventory">Inventory to save</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Success or failure result</returns>
+    Task<Result> SaveAsync(
+        InventoryEntity inventory,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes an inventory (e.g., when actor dies or inventory is dropped).
+    /// </summary>
+    /// <param name="inventoryId">Inventory to delete</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Success or failure result</returns>
+    Task<Result> DeleteAsync(
+        InventoryId inventoryId,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Darklands.Core/Features/Inventory/Application/Queries/GetInventoryQuery.cs
+++ b/src/Darklands.Core/Features/Inventory/Application/Queries/GetInventoryQuery.cs
@@ -1,0 +1,12 @@
+using CSharpFunctionalExtensions;
+using Darklands.Core.Domain.Common;
+using MediatR;
+
+namespace Darklands.Core.Features.Inventory.Application.Queries;
+
+/// <summary>
+/// Query to retrieve an actor's inventory state.
+/// Returns DTO to prevent presentation layer from directly accessing domain entities.
+/// </summary>
+/// <param name="ActorId">Actor whose inventory to retrieve</param>
+public sealed record GetInventoryQuery(ActorId ActorId) : IRequest<Result<InventoryDto>>;

--- a/src/Darklands.Core/Features/Inventory/Application/Queries/GetInventoryQueryHandler.cs
+++ b/src/Darklands.Core/Features/Inventory/Application/Queries/GetInventoryQueryHandler.cs
@@ -1,0 +1,43 @@
+using CSharpFunctionalExtensions;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Darklands.Core.Features.Inventory.Application.Queries;
+
+/// <summary>
+/// Handler for GetInventoryQuery.
+/// Returns inventory state as DTO (prevents presentation from accessing domain entities).
+/// </summary>
+public sealed class GetInventoryQueryHandler
+    : IRequestHandler<GetInventoryQuery, Result<InventoryDto>>
+{
+    private readonly IInventoryRepository _inventories;
+    private readonly ILogger<GetInventoryQueryHandler> _logger;
+
+    public GetInventoryQueryHandler(
+        IInventoryRepository inventories,
+        ILogger<GetInventoryQueryHandler> logger)
+    {
+        _inventories = inventories ?? throw new ArgumentNullException(nameof(inventories));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<Result<InventoryDto>> Handle(
+        GetInventoryQuery query,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogDebug(
+            "Retrieving inventory for actor {ActorId}",
+            query.ActorId);
+
+        return await _inventories
+            .GetByActorIdAsync(query.ActorId, cancellationToken)
+            .Map(inventory => new InventoryDto(
+                inventory.Id,
+                query.ActorId,
+                inventory.Capacity,
+                inventory.Count,
+                inventory.IsFull,
+                inventory.Items));
+    }
+}

--- a/src/Darklands.Core/Features/Inventory/Application/Queries/InventoryDto.cs
+++ b/src/Darklands.Core/Features/Inventory/Application/Queries/InventoryDto.cs
@@ -1,0 +1,23 @@
+using Darklands.Core.Domain.Common;
+using Darklands.Core.Features.Inventory.Domain;
+
+namespace Darklands.Core.Features.Inventory.Application.Queries;
+
+/// <summary>
+/// Data Transfer Object for inventory state.
+/// Prevents presentation layer from directly accessing domain entities.
+/// Changes to Inventory entity don't break UI code.
+/// </summary>
+/// <param name="InventoryId">Unique inventory identifier</param>
+/// <param name="ActorId">Owner of this inventory</param>
+/// <param name="Capacity">Maximum number of items</param>
+/// <param name="Count">Current number of items</param>
+/// <param name="IsFull">True if at capacity</param>
+/// <param name="Items">Read-only list of item IDs</param>
+public sealed record InventoryDto(
+    InventoryId InventoryId,
+    ActorId ActorId,
+    int Capacity,
+    int Count,
+    bool IsFull,
+    IReadOnlyList<ItemId> Items);

--- a/src/Darklands.Core/Features/Inventory/Domain/Inventory.cs
+++ b/src/Darklands.Core/Features/Inventory/Domain/Inventory.cs
@@ -1,0 +1,113 @@
+using CSharpFunctionalExtensions;
+using Darklands.Core.Domain.Common;
+
+namespace Darklands.Core.Features.Inventory.Domain;
+
+/// <summary>
+/// Represents a slot-based inventory with fixed capacity.
+/// </summary>
+/// <remarks>
+/// ARCHITECTURE: Inventory stores ItemId references, NOT Item entities.
+/// This creates clean separation:
+/// - Inventory Feature: Container logic (add/remove/query)
+/// - Item Feature: Item properties (name, type, weight) [Future VS]
+/// - Presentation: Joins data for display
+///
+/// WHY: Single Responsibility + Testability + Parallel Development
+/// </remarks>
+public sealed class Inventory
+{
+    private readonly List<ItemId> _items;
+
+    /// <summary>
+    /// Unique identifier for this inventory.
+    /// </summary>
+    public InventoryId Id { get; private init; }
+
+    /// <summary>
+    /// Maximum number of items this inventory can hold.
+    /// </summary>
+    public int Capacity { get; private init; }
+
+    /// <summary>
+    /// Current number of items in inventory.
+    /// </summary>
+    public int Count => _items.Count;
+
+    /// <summary>
+    /// True if inventory has reached capacity.
+    /// </summary>
+    public bool IsFull => Count >= Capacity;
+
+    /// <summary>
+    /// Read-only view of items in this inventory.
+    /// </summary>
+    public IReadOnlyList<ItemId> Items => _items.AsReadOnly();
+
+    private Inventory(InventoryId id, int capacity)
+    {
+        Id = id;
+        Capacity = capacity;
+        _items = new List<ItemId>(capacity);
+    }
+
+    /// <summary>
+    /// Creates a new inventory with specified capacity.
+    /// </summary>
+    /// <param name="id">Unique inventory identifier</param>
+    /// <param name="capacity">Maximum number of items (must be positive)</param>
+    /// <returns>Result containing new Inventory or error message</returns>
+    public static Result<Inventory> Create(InventoryId id, int capacity)
+    {
+        if (capacity <= 0)
+            return Result.Failure<Inventory>("Capacity must be positive");
+
+        if (capacity > 100)
+            return Result.Failure<Inventory>("Capacity cannot exceed 100");
+
+        return Result.Success(new Inventory(id, capacity));
+    }
+
+    /// <summary>
+    /// Adds an item to this inventory.
+    /// </summary>
+    /// <param name="itemId">ID of item to add</param>
+    /// <returns>Success if added, Failure with reason if not</returns>
+    public Result AddItem(ItemId itemId)
+    {
+        // BUSINESS RULE: Cannot add to full inventory
+        if (IsFull)
+            return Result.Failure("Inventory is full");
+
+        // BUSINESS RULE: Cannot add duplicate items (items are unique)
+        if (_items.Contains(itemId))
+            return Result.Failure("Item already in inventory");
+
+        _items.Add(itemId);
+        return Result.Success();
+    }
+
+    /// <summary>
+    /// Removes an item from this inventory.
+    /// </summary>
+    /// <param name="itemId">ID of item to remove</param>
+    /// <returns>Success if removed, Failure if not found</returns>
+    public Result RemoveItem(ItemId itemId)
+    {
+        if (!_items.Contains(itemId))
+            return Result.Failure("Item not found in inventory");
+
+        _items.Remove(itemId);
+        return Result.Success();
+    }
+
+    /// <summary>
+    /// Checks if this inventory contains an item.
+    /// </summary>
+    public bool Contains(ItemId itemId) => _items.Contains(itemId);
+
+    /// <summary>
+    /// Removes all items from this inventory.
+    /// </summary>
+    public void Clear() => _items.Clear();
+}

--- a/src/Darklands.Core/Features/Inventory/Domain/InventoryId.cs
+++ b/src/Darklands.Core/Features/Inventory/Domain/InventoryId.cs
@@ -1,0 +1,26 @@
+namespace Darklands.Core.Features.Inventory.Domain;
+
+/// <summary>
+/// Uniquely identifies an inventory instance.
+/// Value type with value semantics - two InventoryIds with the same Guid are equal.
+/// </summary>
+public readonly record struct InventoryId(Guid Value)
+{
+    /// <summary>
+    /// Creates a new unique InventoryId.
+    /// </summary>
+    public static InventoryId NewId() => new(Guid.NewGuid());
+
+    /// <summary>
+    /// Creates an InventoryId from a string representation.
+    /// </summary>
+    /// <param name="value">String representation of a Guid</param>
+    /// <returns>InventoryId parsed from the string</returns>
+    /// <exception cref="FormatException">If the string is not a valid Guid format</exception>
+    public static InventoryId From(string value) => new(Guid.Parse(value));
+
+    /// <summary>
+    /// Returns the string representation of this InventoryId.
+    /// </summary>
+    public override string ToString() => Value.ToString();
+}

--- a/src/Darklands.Core/Features/Inventory/Infrastructure/InMemoryInventoryRepository.cs
+++ b/src/Darklands.Core/Features/Inventory/Infrastructure/InMemoryInventoryRepository.cs
@@ -1,0 +1,73 @@
+using CSharpFunctionalExtensions;
+using Darklands.Core.Domain.Common;
+using Darklands.Core.Features.Inventory.Application;
+using Microsoft.Extensions.Logging;
+using InventoryEntity = Darklands.Core.Features.Inventory.Domain.Inventory;
+using InventoryId = Darklands.Core.Features.Inventory.Domain.InventoryId;
+
+namespace Darklands.Core.Features.Inventory.Infrastructure;
+
+/// <summary>
+/// In-memory inventory repository for MVP.
+/// </summary>
+/// <remarks>
+/// THREAD SAFETY: Not thread-safe by design (single-player game, Godot main thread only).
+/// PERSISTENCE: State lost on application restart (acceptable for MVP).
+/// FUTURE: Replace with SQLite/JSON persistence without changing interface.
+/// </remarks>
+public sealed class InMemoryInventoryRepository : IInventoryRepository
+{
+    private readonly Dictionary<ActorId, InventoryEntity> _inventoriesByActor = new();
+    private readonly ILogger<InMemoryInventoryRepository> _logger;
+    private const int DefaultCapacity = 20;
+
+    public InMemoryInventoryRepository(ILogger<InMemoryInventoryRepository> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public Task<Result<InventoryEntity>> GetByActorIdAsync(
+        ActorId actorId,
+        CancellationToken cancellationToken = default)
+    {
+        if (!_inventoriesByActor.TryGetValue(actorId, out var inventory))
+        {
+            // DESIGN DECISION: Auto-create inventory with default capacity
+            // WHY: Every player-controlled actor needs an inventory. Explicit creation adds boilerplate.
+            // ALTERNATIVE: Require explicit CreateInventoryCommand (more ceremony, no clear benefit for MVP)
+
+            _logger.LogDebug(
+                "Auto-creating inventory for actor {ActorId} with capacity {Capacity}",
+                actorId,
+                DefaultCapacity);
+
+            inventory = InventoryEntity.Create(InventoryId.NewId(), DefaultCapacity).Value;
+            _inventoriesByActor[actorId] = inventory;
+        }
+
+        return Task.FromResult(Result.Success(inventory));
+    }
+
+    public Task<Result> SaveAsync(
+        InventoryEntity inventory,
+        CancellationToken cancellationToken = default)
+    {
+        // In-memory: No-op (already in dictionary, passed by reference)
+        // Future implementations: Write to SQLite/JSON here
+        return Task.FromResult(Result.Success());
+    }
+
+    public Task<Result> DeleteAsync(
+        InventoryId inventoryId,
+        CancellationToken cancellationToken = default)
+    {
+        var toRemove = _inventoriesByActor.FirstOrDefault(kvp => kvp.Value.Id == inventoryId);
+        if (toRemove.Key != default)
+        {
+            _inventoriesByActor.Remove(toRemove.Key);
+            _logger.LogDebug("Deleted inventory {InventoryId}", inventoryId);
+        }
+
+        return Task.FromResult(Result.Success());
+    }
+}

--- a/tests/Darklands.Core.Tests/Features/Inventory/Application/Commands/AddItemCommandHandlerTests.cs
+++ b/tests/Darklands.Core.Tests/Features/Inventory/Application/Commands/AddItemCommandHandlerTests.cs
@@ -1,0 +1,80 @@
+using Darklands.Core.Domain.Common;
+using Darklands.Core.Features.Inventory.Application.Commands;
+using Darklands.Core.Features.Inventory.Infrastructure;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Darklands.Core.Tests.Features.Inventory.Application.Commands;
+
+[Trait("Category", "Phase2")]
+[Trait("Category", "Unit")]
+public class AddItemCommandHandlerTests
+{
+    [Fact]
+    public async Task Handle_ValidItem_ShouldAddToInventory()
+    {
+        // Arrange
+        var actorId = ActorId.NewId();
+        var itemId = ItemId.NewId();
+        var repository = new InMemoryInventoryRepository(NullLogger<InMemoryInventoryRepository>.Instance);
+        var handler = new AddItemCommandHandler(repository, NullLogger<AddItemCommandHandler>.Instance);
+        var command = new AddItemCommand(actorId, itemId);
+
+        // Act
+        var result = await handler.Handle(command, default);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+
+        var inventory = await repository.GetByActorIdAsync(actorId);
+        inventory.Value.Contains(itemId).Should().BeTrue();
+        inventory.Value.Count.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Handle_FullInventory_ShouldFail()
+    {
+        // BUSINESS RULE: Cannot add items when inventory is full
+
+        // Arrange
+        var actorId = ActorId.NewId();
+        var repository = new InMemoryInventoryRepository(NullLogger<InMemoryInventoryRepository>.Instance);
+        var handler = new AddItemCommandHandler(repository, NullLogger<AddItemCommandHandler>.Instance);
+
+        // Fill inventory (default capacity is 20)
+        for (int i = 0; i < 20; i++)
+        {
+            await handler.Handle(new AddItemCommand(actorId, ItemId.NewId()), default);
+        }
+
+        // Act
+        var result = await handler.Handle(new AddItemCommand(actorId, ItemId.NewId()), default);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("full");
+    }
+
+    [Fact]
+    public async Task Handle_DuplicateItem_ShouldFail()
+    {
+        // BUSINESS RULE: Cannot add same item twice
+
+        // Arrange
+        var actorId = ActorId.NewId();
+        var itemId = ItemId.NewId();
+        var repository = new InMemoryInventoryRepository(NullLogger<InMemoryInventoryRepository>.Instance);
+        var handler = new AddItemCommandHandler(repository, NullLogger<AddItemCommandHandler>.Instance);
+
+        // Add item once
+        await handler.Handle(new AddItemCommand(actorId, itemId), default);
+
+        // Act
+        var result = await handler.Handle(new AddItemCommand(actorId, itemId), default);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("already in inventory");
+    }
+}

--- a/tests/Darklands.Core.Tests/Features/Inventory/Application/Commands/RemoveItemCommandHandlerTests.cs
+++ b/tests/Darklands.Core.Tests/Features/Inventory/Application/Commands/RemoveItemCommandHandlerTests.cs
@@ -1,0 +1,54 @@
+using Darklands.Core.Domain.Common;
+using Darklands.Core.Features.Inventory.Application.Commands;
+using Darklands.Core.Features.Inventory.Infrastructure;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Darklands.Core.Tests.Features.Inventory.Application.Commands;
+
+[Trait("Category", "Phase2")]
+[Trait("Category", "Unit")]
+public class RemoveItemCommandHandlerTests
+{
+    [Fact]
+    public async Task Handle_ExistingItem_ShouldRemoveFromInventory()
+    {
+        // Arrange
+        var actorId = ActorId.NewId();
+        var itemId = ItemId.NewId();
+        var repository = new InMemoryInventoryRepository(NullLogger<InMemoryInventoryRepository>.Instance);
+        var addHandler = new AddItemCommandHandler(repository, NullLogger<AddItemCommandHandler>.Instance);
+        var removeHandler = new RemoveItemCommandHandler(repository, NullLogger<RemoveItemCommandHandler>.Instance);
+
+        // Add item first
+        await addHandler.Handle(new AddItemCommand(actorId, itemId), default);
+
+        // Act
+        var result = await removeHandler.Handle(new RemoveItemCommand(actorId, itemId), default);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+
+        var inventory = await repository.GetByActorIdAsync(actorId);
+        inventory.Value.Contains(itemId).Should().BeFalse();
+        inventory.Value.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Handle_NonExistentItem_ShouldFail()
+    {
+        // Arrange
+        var actorId = ActorId.NewId();
+        var itemId = ItemId.NewId();
+        var repository = new InMemoryInventoryRepository(NullLogger<InMemoryInventoryRepository>.Instance);
+        var handler = new RemoveItemCommandHandler(repository, NullLogger<RemoveItemCommandHandler>.Instance);
+
+        // Act
+        var result = await handler.Handle(new RemoveItemCommand(actorId, itemId), default);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("not found");
+    }
+}

--- a/tests/Darklands.Core.Tests/Features/Inventory/Application/Queries/GetInventoryQueryHandlerTests.cs
+++ b/tests/Darklands.Core.Tests/Features/Inventory/Application/Queries/GetInventoryQueryHandlerTests.cs
@@ -1,0 +1,65 @@
+using Darklands.Core.Domain.Common;
+using Darklands.Core.Features.Inventory.Application.Commands;
+using Darklands.Core.Features.Inventory.Application.Queries;
+using Darklands.Core.Features.Inventory.Infrastructure;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Darklands.Core.Tests.Features.Inventory.Application.Queries;
+
+[Trait("Category", "Phase2")]
+[Trait("Category", "Unit")]
+public class GetInventoryQueryHandlerTests
+{
+    [Fact]
+    public async Task Handle_ExistingInventory_ShouldReturnDto()
+    {
+        // Arrange
+        var actorId = ActorId.NewId();
+        var item1 = ItemId.NewId();
+        var item2 = ItemId.NewId();
+        var repository = new InMemoryInventoryRepository(NullLogger<InMemoryInventoryRepository>.Instance);
+        var addHandler = new AddItemCommandHandler(repository, NullLogger<AddItemCommandHandler>.Instance);
+        var queryHandler = new GetInventoryQueryHandler(repository, NullLogger<GetInventoryQueryHandler>.Instance);
+
+        // Add 2 items
+        await addHandler.Handle(new AddItemCommand(actorId, item1), default);
+        await addHandler.Handle(new AddItemCommand(actorId, item2), default);
+
+        // Act
+        var result = await queryHandler.Handle(new GetInventoryQuery(actorId), default);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        var dto = result.Value;
+        dto.ActorId.Should().Be(actorId);
+        dto.Count.Should().Be(2);
+        dto.Capacity.Should().Be(20); // Default capacity
+        dto.IsFull.Should().BeFalse();
+        dto.Items.Should().Contain(new[] { item1, item2 });
+    }
+
+    [Fact]
+    public async Task Handle_NewActor_ShouldAutoCreateInventory()
+    {
+        // DESIGN DECISION: Auto-create inventory on first access
+
+        // Arrange
+        var actorId = ActorId.NewId();
+        var repository = new InMemoryInventoryRepository(NullLogger<InMemoryInventoryRepository>.Instance);
+        var queryHandler = new GetInventoryQueryHandler(repository, NullLogger<GetInventoryQueryHandler>.Instance);
+
+        // Act
+        var result = await queryHandler.Handle(new GetInventoryQuery(actorId), default);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        var dto = result.Value;
+        dto.ActorId.Should().Be(actorId);
+        dto.Count.Should().Be(0);
+        dto.Capacity.Should().Be(20); // Default capacity
+        dto.IsFull.Should().BeFalse();
+        dto.Items.Should().BeEmpty();
+    }
+}

--- a/tests/Darklands.Core.Tests/Features/Inventory/Domain/InventoryTests.cs
+++ b/tests/Darklands.Core.Tests/Features/Inventory/Domain/InventoryTests.cs
@@ -1,0 +1,188 @@
+using Darklands.Core.Domain.Common;
+using FluentAssertions;
+using Xunit;
+using InventoryEntity = Darklands.Core.Features.Inventory.Domain.Inventory;
+using InventoryId = Darklands.Core.Features.Inventory.Domain.InventoryId;
+
+namespace Darklands.Core.Tests.Features.Inventory.Domain;
+
+[Trait("Category", "Phase1")]
+[Trait("Category", "Unit")]
+public class InventoryTests
+{
+    #region Create Tests
+
+    [Fact]
+    public void Create_WithValidCapacity_ShouldSucceed()
+    {
+        // Arrange & Act
+        var result = InventoryEntity.Create(InventoryId.NewId(), capacity: 20);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Capacity.Should().Be(20);
+        result.Value.Count.Should().Be(0);
+        result.Value.IsFull.Should().BeFalse();
+        result.Value.Items.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(-100)]
+    public void Create_WithNonPositiveCapacity_ShouldFail(int invalidCapacity)
+    {
+        // Act
+        var result = InventoryEntity.Create(InventoryId.NewId(), invalidCapacity);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("positive");
+    }
+
+    [Fact]
+    public void Create_WithCapacityOver100_ShouldFail()
+    {
+        // BUSINESS RULE: Maximum inventory capacity is 100 slots
+
+        // Act
+        var result = InventoryEntity.Create(InventoryId.NewId(), capacity: 101);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("exceed 100");
+    }
+
+    #endregion
+
+    #region AddItem Tests
+
+    [Fact]
+    public void AddItem_WhenNotFull_ShouldSucceed()
+    {
+        // Arrange
+        var inventory = InventoryEntity.Create(InventoryId.NewId(), capacity: 3).Value;
+        var itemId = ItemId.NewId();
+
+        // Act
+        var result = inventory.AddItem(itemId);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        inventory.Contains(itemId).Should().BeTrue();
+        inventory.Count.Should().Be(1);
+    }
+
+    [Fact]
+    public void AddItem_WhenFull_ShouldFail()
+    {
+        // BUSINESS RULE: Cannot add items to full inventory
+
+        // Arrange
+        var inventory = InventoryEntity.Create(InventoryId.NewId(), capacity: 2).Value;
+        inventory.AddItem(ItemId.NewId());
+        inventory.AddItem(ItemId.NewId());
+
+        // Act
+        var result = inventory.AddItem(ItemId.NewId());
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("full");
+        inventory.Count.Should().Be(2);
+    }
+
+    [Fact]
+    public void AddItem_WhenDuplicateItem_ShouldFail()
+    {
+        // BUSINESS RULE: Items are unique, cannot add same item twice
+
+        // Arrange
+        var inventory = InventoryEntity.Create(InventoryId.NewId(), capacity: 5).Value;
+        var itemId = ItemId.NewId();
+        inventory.AddItem(itemId);
+
+        // Act
+        var result = inventory.AddItem(itemId);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("already in inventory");
+        inventory.Count.Should().Be(1);
+    }
+
+    #endregion
+
+    #region RemoveItem Tests
+
+    [Fact]
+    public void RemoveItem_WhenExists_ShouldSucceed()
+    {
+        // Arrange
+        var inventory = InventoryEntity.Create(InventoryId.NewId(), capacity: 5).Value;
+        var itemId = ItemId.NewId();
+        inventory.AddItem(itemId);
+
+        // Act
+        var result = inventory.RemoveItem(itemId);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        inventory.Contains(itemId).Should().BeFalse();
+        inventory.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public void RemoveItem_WhenNotExists_ShouldFail()
+    {
+        // Arrange
+        var inventory = InventoryEntity.Create(InventoryId.NewId(), capacity: 5).Value;
+
+        // Act
+        var result = inventory.RemoveItem(ItemId.NewId());
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("not found");
+    }
+
+    #endregion
+
+    #region IsFull Tests
+
+    [Fact]
+    public void IsFull_WhenAtCapacity_ShouldBeTrue()
+    {
+        // Arrange
+        var inventory = InventoryEntity.Create(InventoryId.NewId(), capacity: 2).Value;
+        inventory.AddItem(ItemId.NewId());
+        inventory.AddItem(ItemId.NewId());
+
+        // Assert
+        inventory.IsFull.Should().BeTrue();
+    }
+
+    #endregion
+
+    #region Clear Tests
+
+    [Fact]
+    public void Clear_ShouldRemoveAllItems()
+    {
+        // Arrange
+        var inventory = InventoryEntity.Create(InventoryId.NewId(), capacity: 5).Value;
+        inventory.AddItem(ItemId.NewId());
+        inventory.AddItem(ItemId.NewId());
+        inventory.AddItem(ItemId.NewId());
+
+        // Act
+        inventory.Clear();
+
+        // Assert
+        inventory.Count.Should().Be(0);
+        inventory.Items.Should().BeEmpty();
+        inventory.IsFull.Should().BeFalse();
+    }
+
+    #endregion
+}

--- a/tests/Darklands.Core.Tests/Features/Inventory/Infrastructure/InMemoryInventoryRepositoryTests.cs
+++ b/tests/Darklands.Core.Tests/Features/Inventory/Infrastructure/InMemoryInventoryRepositoryTests.cs
@@ -1,0 +1,92 @@
+using Darklands.Core.Domain.Common;
+using Darklands.Core.Features.Inventory.Infrastructure;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Darklands.Core.Tests.Features.Inventory.Infrastructure;
+
+[Trait("Category", "Phase3")]
+[Trait("Category", "Integration")]
+public class InMemoryInventoryRepositoryTests
+{
+    [Fact]
+    public async Task GetByActorIdAsync_FirstTime_ShouldAutoCreateInventory()
+    {
+        // DESIGN DECISION: Auto-create inventory with default capacity (20 slots)
+
+        // Arrange
+        var actorId = ActorId.NewId();
+        var repository = new InMemoryInventoryRepository(NullLogger<InMemoryInventoryRepository>.Instance);
+
+        // Act
+        var result = await repository.GetByActorIdAsync(actorId);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Capacity.Should().Be(20); // Default capacity
+        result.Value.Count.Should().Be(0);
+        result.Value.IsFull.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetByActorIdAsync_SecondTime_ShouldReturnSameInventory()
+    {
+        // WHY: Repository must return same instance for idempotency
+
+        // Arrange
+        var actorId = ActorId.NewId();
+        var itemId = ItemId.NewId();
+        var repository = new InMemoryInventoryRepository(NullLogger<InMemoryInventoryRepository>.Instance);
+
+        // Get inventory first time and add item
+        var inv1 = await repository.GetByActorIdAsync(actorId);
+        inv1.Value.AddItem(itemId);
+
+        // Act
+        var inv2 = await repository.GetByActorIdAsync(actorId);
+
+        // Assert
+        inv2.Value.Contains(itemId).Should().BeTrue(); // Item persisted
+        inv2.Value.Id.Should().Be(inv1.Value.Id); // Same instance
+    }
+
+    [Fact]
+    public async Task SaveAsync_ShouldSucceed()
+    {
+        // WHY: In-memory implementation is no-op but must return success
+
+        // Arrange
+        var actorId = ActorId.NewId();
+        var repository = new InMemoryInventoryRepository(NullLogger<InMemoryInventoryRepository>.Instance);
+        var inventory = await repository.GetByActorIdAsync(actorId);
+
+        // Act
+        var result = await repository.SaveAsync(inventory.Value);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task DeleteAsync_ShouldRemoveInventory()
+    {
+        // Arrange
+        var actorId = ActorId.NewId();
+        var repository = new InMemoryInventoryRepository(NullLogger<InMemoryInventoryRepository>.Instance);
+
+        // Get inventory (auto-creates)
+        var inventory = await repository.GetByActorIdAsync(actorId);
+        var inventoryId = inventory.Value.Id;
+
+        // Act
+        var deleteResult = await repository.DeleteAsync(inventoryId);
+
+        // Assert
+        deleteResult.IsSuccess.Should().BeTrue();
+
+        // Verify: Getting inventory again auto-creates a NEW one
+        var newInventory = await repository.GetByActorIdAsync(actorId);
+        newInventory.Value.Id.Should().NotBe(inventoryId); // Different instance
+    }
+}


### PR DESCRIPTION
## Summary

Implements slot-based inventory system (MVP) with 20-slot capacity, add/remove operations, and Godot UI test panel.

### Implementation (4 Phases - Clean Architecture)

**Phase 1: Domain Layer** ✅
- ItemId (Domain/Common) - Shared 16-byte primitive for 3+ features
- InventoryId - Feature-specific identifier  
- Inventory entity - Capacity enforcement (1-100 slots), duplicate prevention, Result<T> errors
- Tests: 10 methods (12 executions), 100% pass (15ms)

**Phase 2: Application Layer** ✅
- Commands: AddItemCommand, RemoveItemCommand (with handlers)
- Query: GetInventoryQuery + InventoryDto (prevents presentation from accessing domain)
- IInventoryRepository - Interface in Application (Dependency Inversion Principle)
- Railway-Oriented: Handlers use `.Bind()`, `.Map()`, `.Tap()`
- Tests: 7 tests, 100% pass (2ms)

**Phase 3: Infrastructure Layer** ✅
- InMemoryInventoryRepository - Auto-creates inventory on first access (20-slot default)
- DI registration in GameStrapper (AddSingleton pattern)
- Tests: 4 repository tests, 100% pass (3ms)

**Phase 4: Presentation Layer** ✅
- InventoryPanelNode.cs - Godot UI with ServiceLocator pattern
- InventoryTestScene.tscn - GridContainer (10×2 = 20 slots), test buttons
- No events in MVP: UI queries on-demand after commands
- Dynamic slot visuals: Green (filled), gray (empty)

### Architecture Compliance

- ✅ **ADR-002**: Zero Godot dependencies in Core, ServiceLocator ONLY in _Ready()
- ✅ **ADR-003**: Result<T> functional error handling throughout
- ✅ **ADR-004**: ItemId in Domain/Common (shared primitive pattern)
- ✅ **Dependency Inversion**: Interface in Application, implementation in Infrastructure

### Test Coverage

**Total: 23 tests, 100% pass rate, <20ms execution**
- Phase 1 (Domain): 10 test methods (12 executions) - 15ms
- Phase 2 (Application): 7 handler tests - 2ms  
- Phase 3 (Infrastructure): 4 repository tests - 3ms
- Phase 4 (Presentation): Manual testing required ⚠️

### Manual Testing Checklist

**How to Test:**
1. Open Godot Editor
2. Run `godot_project/test_scenes/InventoryTestScene.tscn`
3. Click "➕ Add Test Item" → Verify slot fills (green), capacity updates (1/20)
4. Add 20 items total → Button disables, shows "🚫 Inventory Full"
5. Try 21st item → Verify error handling (should fail gracefully)
6. Click "➖ Remove Last Item" → Slot empties, capacity decreases
7. Console shows structured logs (ILogger, NOT GD.Print) ✅

**Expected Results:**
- ✅ UI responsive, buttons disable/enable correctly
- ✅ Capacity label updates: "📦 Inventory: X/20"
- ✅ Slots show item ID (last 4 chars) when filled
- ✅ Full inventory prevents adding 21st item
- ✅ Structured logging visible in console

### Key Insights

1. **Namespace Collision Fix**: Used `InventoryEntity` alias when namespace path contains "Inventory"
2. **Repository Pattern**: Returns reference (not copy), changes auto-persist in-memory
3. **Auto-Creation Design**: Pragmatic for MVP (all player actors need inventories)
4. **Query-Based UI**: No events in MVP, UI refreshes via GetInventoryQuery after commands
5. **Godot 4 Specifics**: Manual GetNode<T>(), StyleBoxFlat individual border properties

### Files Changed

**Core (Pure C#):**
- Domain: ItemId.cs, InventoryId.cs, Inventory.cs
- Application: Commands, Queries, Handlers, IInventoryRepository, DTO
- Infrastructure: InMemoryInventoryRepository.cs, DI registration

**Presentation (Godot):**
- Components/InventoryPanelNode.cs
- godot_project/test_scenes/InventoryTestScene.tscn

**Tests:**
- Domain: InventoryTests.cs (10 methods)
- Application: Handler tests (7 tests)
- Infrastructure: Repository tests (4 tests)

### Breaking Changes

None - This is a new feature (additive only).

### Future Work (Deferred)

- ❌ Item definitions (name, sprite, properties) → VS_009
- ❌ Spatial grid (tetris placement) → VS_017 (if playtesting proves need)
- ❌ Equipment slots (weapon, armor) → Separate VS
- ❌ Save/load persistence → Separate Save System VS

### Relates To

- Closes #VS_008
- Blocks: VS_009 (Item Definitions - requires ItemId from this PR)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>